### PR TITLE
Fixed a bug raising an exception if existing field contains a null value

### DIFF
--- a/sources/lib/Model/FlexibleEntity/FlexibleContainer.php
+++ b/sources/lib/Model/FlexibleEntity/FlexibleContainer.php
@@ -60,7 +60,7 @@ abstract class FlexibleContainer implements FlexibleEntityInterface, \IteratorAg
         $output = [];
 
         foreach ($fields as $name) {
-            if (isset($this->container[$name])) {
+            if (array_key_exists($name, $this->container)) {
                 $output[$name] = $this->container[$name];
             } else {
                 throw new \InvalidArgumentException(
@@ -123,7 +123,7 @@ abstract class FlexibleContainer implements FlexibleEntityInterface, \IteratorAg
                 ->container[$attribute]
                 ;
         case 'has':
-            return (bool) isset($this->container[$attribute]);
+            return array_key_exists($attribute, $this->container);
         case 'clear':
             unset ($this->checkAttribute($attribute)->container[$attribute]);
 
@@ -144,7 +144,7 @@ abstract class FlexibleContainer implements FlexibleEntityInterface, \IteratorAg
      */
     protected function checkAttribute($attribute)
     {
-        if (!isset($this->container[$attribute])) {
+        if (!array_key_exists($attribute, $this->container)) {
             throw new ModelException(
                 sprintf(
                     "No such attribute '%s'. Available attributes are {%s}",

--- a/sources/tests/Unit/Model/FlexibleEntity/FlexibleContainer.php
+++ b/sources/tests/Unit/Model/FlexibleEntity/FlexibleContainer.php
@@ -33,15 +33,15 @@ class FlexibleContainer extends Atoum
     public function testFields()
     {
         $container = $this->newTestedInstance()
-            ->hydrate(["a" => "one", "b" => "two", "c" => "three"])
+            ->hydrate(["a" => "one", "b" => "two", "c" => null])
             ;
         $this
             ->array($container->fields())
-            ->isIdenticalTo(["a" => "one", "b" => "two", "c" => "three"])
+            ->isIdenticalTo(["a" => "one", "b" => "two", "c" => null])
             ->array($container->fields(["a"]))
             ->isIdenticalTo(["a" => "one"])
             ->array($container->fields(["a", "c"]))
-            ->isIdenticalTo(["a" => "one", "c" => "three"])
+            ->isIdenticalTo(["a" => "one", "c" => null])
             ->array($container->fields([]))
             ->isIdenticalTo([])
             ->exception(function() use ($container) { return $container->fields(["d"]); })
@@ -112,13 +112,15 @@ class FlexibleContainer extends Atoum
     public function testGenericHas()
     {
         $container = $this->newTestedInstance()
-            ->hydrate(["a" => "one", "b" => "two", "c" => "three"])
+            ->hydrate(["a" => "one", "b" => "two", "c" => null])
             ;
         $this
             ->boolean($container->hasA())
             ->isTrue()
             ->boolean($container->hasPika())
             ->isFalse()
+            ->boolean($container->hasC())
+            ->isTrue()
             ;
     }
 


### PR DESCRIPTION
Replaced isset() calls with array_key_exists(), which allows testing and fetching fields containing a null value.