### PR TITLE
Fix defferable keys with schema

### DIFF
--- a/sources/lib/ModelLayer/ModelLayer.php
+++ b/sources/lib/ModelLayer/ModelLayer.php
@@ -92,7 +92,16 @@ abstract class ModelLayer extends Client
         } else {
             $string = join(
                 ', ',
-                array_map(function ($key) { $this->escapeIdentifier($key); }, $keys)
+                array_map(
+                    function ($key) {
+                        $parts = explode('.', $key);
+                        foreach ($parts as $part) {
+                            $escapedParts[] = $this->escapeIdentifier($part);
+                        }
+                        return join('.', $escapedParts);
+                    },
+                    $keys
+                )
             );
         }
 


### PR DESCRIPTION
Add ability to deffer a constraint on a specific schema escaping  'schema.constraint' in '"schema"."constraint"' instead of previous way '"schema.constraint"'