### PR TITLE
Add subqueries

### DIFF
--- a/sources/lib/Model/ModelTrait/ReadQueries.php
+++ b/sources/lib/Model/ModelTrait/ReadQueries.php
@@ -347,14 +347,25 @@ trait ReadQueries
         $where = new Where();
 
         foreach ($values as $field => $value) {
-            $where->andWhere(
-                sprintf(
-                    "%s = $*::%s",
-                    $this->escapeIdentifier($field),
-                    $this->getStructure()->getTypeFor($field)
-                ),
-                [$value]
-            );
+            if (is_array($value)) {
+                $where->andWhere(
+                    sprintf(
+                        '%s = (%s)',
+                        $this->escapeIdentifier($field),
+                        array_shift($value)
+                    ),
+                    $value
+                );
+            } else {
+                $where->andWhere(
+                    sprintf(
+                        "%s = $*::%s",
+                        $this->escapeIdentifier($field),
+                        $this->getStructure()->getTypeFor($field)
+                    ),
+                    [$value]
+                );
+            }
         }
 
         return $where;

--- a/sources/lib/Model/ModelTrait/WriteQueries.php
+++ b/sources/lib/Model/ModelTrait/WriteQueries.php
@@ -121,6 +121,7 @@ trait WriteQueries
             ;
         $parameters = $this->getParametersList($updates);
         $update_strings = [];
+        $values = [];
 
         foreach ($updates as $field_name => $new_value) {
             $update_strings[] = sprintf(
@@ -128,6 +129,11 @@ trait WriteQueries
                 $this->escapeIdentifier($field_name),
                 $parameters[$field_name]
             );
+            if (is_array($new_value)) {
+                $values = array_merge($values, array_slice($new_value, 1));
+            } else {
+                $values[] = $new_value;
+            }
         }
 
         $sql = strtr(
@@ -139,16 +145,6 @@ trait WriteQueries
                 ':projection' => $this->createProjection()->formatFieldsWithFieldAlias(),
             ]
         );
-
-        $values = [];
-        foreach ($updates as $field => $value) {
-            if (is_array($value)) {
-                $values = array_merge($values, array_slice($value, 1));
-            } else {
-                $values[] = $value;
-            }
-        }
-
         $iterator = $this->query($sql, array_merge($values, $where->getValues()));
 
         if ($iterator->isEmpty()) {

--- a/sources/lib/Model/ModelTrait/WriteQueries.php
+++ b/sources/lib/Model/ModelTrait/WriteQueries.php
@@ -145,6 +145,7 @@ trait WriteQueries
                 ':projection' => $this->createProjection()->formatFieldsWithFieldAlias(),
             ]
         );
+
         $iterator = $this->query($sql, array_merge($values, $where->getValues()));
 
         if ($iterator->isEmpty()) {

--- a/sources/tests/Fixture/NumberFixture.php
+++ b/sources/tests/Fixture/NumberFixture.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of the PommProject/ModelManager package.
+ *
+ * (c) 2014 - 2015 Grégoire HUBERT <hubert.greg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PommProject\ModelManager\Test\Fixture;
+
+use PommProject\ModelManager\Model\FlexibleEntity;
+
+class NumberFixture extends FlexibleEntity
+{
+}

--- a/sources/tests/Fixture/NumberFixtureModel.php
+++ b/sources/tests/Fixture/NumberFixtureModel.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * This file is part of the PommProject/ModelManager package.
+ *
+ * (c) 2014 - 2015 Grégoire HUBERT <hubert.greg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PommProject\ModelManager\Test\Fixture;
+
+use PommProject\Foundation\Session\Session;
+use PommProject\ModelManager\Model\Model;
+use PommProject\ModelManager\Model\ModelTrait\WriteQueries;
+
+class NumberFixtureModel extends Model
+{
+    use WriteQueries;
+
+    public function __construct()
+    {
+        $this->structure = new NumberFixtureStructure();
+        $this->flexible_entity_class = 'PommProject\ModelManager\Test\Fixture\NumberFixture';
+    }
+
+    public function initialize(Session $session)
+    {
+        parent::initialize($session);
+        $this->dropTable();
+        $this->createTable();
+    }
+
+    public function shutdown()
+    {
+        $this->dropTable();
+    }
+
+    protected function createTable()
+    {
+        $sql = <<<SQL
+create temporary table %s (
+    id serial primary key,
+		data int4,
+    created_at timestamptz not null default now()
+)
+SQL;
+        $this->executeAnonymousQuery(sprintf($sql, $this->getStructure()->getRelation()));
+
+        $sql = <<<SQL
+insert into %s (data, created_at) values
+    (
+        1,
+				now()
+    ),
+    (
+        2,
+				now()
+    )
+SQL;
+        $this->executeAnonymousQuery(sprintf($sql, $this->getStructure()->getRelation()));
+
+        return $this;
+    }
+
+    protected function dropTable()
+    {
+        $this
+            ->executeAnonymousQuery(
+                sprintf(
+                    "drop table if exists %s",
+                    $this->getStructure()->getRelation()
+                )
+            )
+            ;
+
+        return $this;
+    }
+}

--- a/sources/tests/Fixture/NumberFixtureModel.php
+++ b/sources/tests/Fixture/NumberFixtureModel.php
@@ -50,11 +50,11 @@ SQL;
 insert into %s (data, created_at) values
     (
         1,
-				now()
+        now()
     ),
     (
         2,
-				now()
+        now()
     )
 SQL;
         $this->executeAnonymousQuery(sprintf($sql, $this->getStructure()->getRelation()));

--- a/sources/tests/Fixture/NumberFixtureStructure.php
+++ b/sources/tests/Fixture/NumberFixtureStructure.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of the PommProject/ModelManager package.
+ *
+ * (c) 2014 - 2015 Grégoire HUBERT <hubert.greg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PommProject\ModelManager\Test\Fixture;
+
+use PommProject\ModelManager\Model\RowStructure;
+
+class NumberFixtureStructure extends RowStructure
+{
+    public function __construct()
+    {
+        $this
+            ->setRelation('number_fixture')
+            ->setPrimaryKey(['id'])
+            ->addField('id', 'int4')
+            ->addField('data', 'int4')
+            ->addField('created_at', 'timestamptz')
+            ;
+    }
+}


### PR DESCRIPTION
This allows you to specify literal SQL in updates and creates.
As an example, to update a row's timestamp
`$model->updateByPk([ 'id' => $id ], [ modifiedAt => [ 'NOW()' ] ]);`