### PR TITLE
add Model::getModel() proxy method

### DIFF
--- a/sources/lib/Model/Model.php
+++ b/sources/lib/Model/Model.php
@@ -22,7 +22,7 @@ use PommProject\ModelManager\Model\FlexibleEntity\FlexibleEntityInterface;
  *
  * @abstract
  * @package     Pomm
- * @copyright   2014 - 2015 Grégoire HUBERT
+ * @copyright   2014 - 2019 Grégoire HUBERT
  * @author      Grégoire HUBERT
  * @license     X11 {@link http://opensource.org/licenses/mit-license.php}
  * @see         ClientInterface
@@ -242,6 +242,22 @@ abstract class Model implements ClientInterface
     {
         return $this->structure;
     }
+
+    /**
+     * getModel
+     *
+     * Proxy to Session::getModel();
+     *
+     * @param  string    model identifier
+     * @return Model
+     */
+    protected function getModel($identifier)
+    {
+        return $this
+            ->getSession()
+            ->getClientUsingPooler('model', $identifier);
+    }
+
 
     /**
      * getFlexibleEntityClass

--- a/sources/tests/Fixture/SimpleFixtureModel.php
+++ b/sources/tests/Fixture/SimpleFixtureModel.php
@@ -37,4 +37,8 @@ class SimpleFixtureModel extends Model
 
         return $this->query($sql, $where->getValues());
     }
+
+    public function testGetModel() {
+        return $this === $this->getModel(self::class);
+    }
 }

--- a/sources/tests/Unit/Model/Model.php
+++ b/sources/tests/Unit/Model/Model.php
@@ -459,6 +459,15 @@ class Model extends BaseTest
             ->object($entity)
             ->isInstanceOf('PommProject\ModelManager\Test\Fixture\SimpleFixture');
     }
+
+    public function testGetModel()
+    {
+        $this
+            ->given($model = $this->getSimpleFixtureModel($this->buildSession()))
+            ->boolean($model->testGetModel())
+            ->isTrue()
+            ;
+    }
 }
 
 class NoStructureNoFlexibleEntityModel extends PommModel


### PR DESCRIPTION
A proxy method to summon a model instance in the model methods, this is
especially needed when writing queries with joins to other tables.

Fixes #49